### PR TITLE
#jira SIM-15687 : only user of same permission group can see dashboards

### DIFF
--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -29,6 +29,10 @@
   "Int ID or `nil` of user associated with current API call."
   nil)
 
+(def ^:dynamic ^Integer *current-user-group*
+  "Int ID or `nil` of user group associated with current API call."
+  nil)
+
 (def ^:dynamic *current-user*
   "Delay that returns the `User` (or nil) associated with the current API call.
    ex. `@*current-user*`"


### PR DESCRIPTION
- creation of an API variable populated by the middleware which is the group_id of the user 
- modification of the listing of dashboard to only include the ones created by user belonging to the same permission group
